### PR TITLE
feat: add composite year+period columns to dim_trade_date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-03-26
+### Added
+- Composite year+period columns to dim_trade_date for BI grouping and filtering:
+  - `trade_year_week_num` (YYYYWW) — composite year+week key, same for all patterns
+  - `trade_yearmonth_{445,454,544}_num` (YYYYMM) — composite year+month keys per pattern
+  - `trade_yearquarter_{445,454,544}_num` (YYYYQ) — composite year+quarter keys per pattern
+  - `trade_month_year_{445,454,544}_nm` — display names with year (e.g., 'March 2026')
+  - `trade_month_year_{445,454,544}_abbr` — abbreviated display (e.g., 'Mar 2026')
+  - `trade_year_month_{445,454,544}_txt` — sortable text format (e.g., '2026-03')
+  - `trade_quarter_year_{445,454,544}_txt` — quarter display with year (e.g., 'Q1 2026')
+  - `trade_month_{445,454,544}_abbr` — three-letter month abbreviations (e.g., 'Mar')
+
 ## [1.0.2] - 2025-12-05
 ### Fixed
 - Extended dim_trade_date range from 2040 to 2045 to ensure complete trade calendar coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `trade_year_month_{445,454,544}_txt` — sortable text format (e.g., '2026-03')
   - `trade_quarter_year_{445,454,544}_txt` — quarter display with year (e.g., 'Q1 2026')
   - `trade_month_{445,454,544}_abbr` — three-letter month abbreviations (e.g., 'Mar')
+  - Dense sequential counters for offset arithmetic across year boundaries:
+    - `trade_day_overall_num` — sequential day number across entire trade calendar
+    - `trade_week_overall_num` — sequential week number (same for all days in a trade week)
+    - `trade_month_{445,454,544}_overall_num` — sequential month number per pattern
 
 ## [1.0.2] - 2025-12-05
 ### Fixed

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,7 +8,7 @@
 config-version: 2
 
 name: 'cdc_dbt_utils'
-version: '2.0.0'
+version: '2.1.0'
 profile: 'cdc_dbt_utils'
 
 

--- a/models/dw_util/dim_trade_date.sql
+++ b/models/dw_util/dim_trade_date.sql
@@ -321,7 +321,90 @@ with date_sequence as (
             when 7 then 'July' when 8 then 'August' when 9 then 'September'
             when 10 then 'October' when 11 then 'November' when 12 then 'December'
         end as trade_month_544_nm
-        
+
+        -- Trade month abbreviations for each pattern
+        , case retail_month_445
+            when 1 then 'Jan' when 2 then 'Feb' when 3 then 'Mar'
+            when 4 then 'Apr' when 5 then 'May' when 6 then 'Jun'
+            when 7 then 'Jul' when 8 then 'Aug' when 9 then 'Sep'
+            when 10 then 'Oct' when 11 then 'Nov' when 12 then 'Dec'
+        end as trade_month_445_abbr
+        , case retail_month_454
+            when 1 then 'Jan' when 2 then 'Feb' when 3 then 'Mar'
+            when 4 then 'Apr' when 5 then 'May' when 6 then 'Jun'
+            when 7 then 'Jul' when 8 then 'Aug' when 9 then 'Sep'
+            when 10 then 'Oct' when 11 then 'Nov' when 12 then 'Dec'
+        end as trade_month_454_abbr
+        , case retail_month_544
+            when 1 then 'Jan' when 2 then 'Feb' when 3 then 'Mar'
+            when 4 then 'Apr' when 5 then 'May' when 6 then 'Jun'
+            when 7 then 'Jul' when 8 then 'Aug' when 9 then 'Sep'
+            when 10 then 'Oct' when 11 then 'Nov' when 12 then 'Dec'
+        end as trade_month_544_abbr
+
+        -- Composite year+week key (YYYYWW format, same for all patterns)
+        , retail_year * 100 + retail_week_num as trade_year_week_num
+
+        -- Composite year+month keys (YYYYMM format, pattern-specific)
+        , retail_year * 100 + retail_month_445 as trade_yearmonth_445_num
+        , retail_year * 100 + retail_month_454 as trade_yearmonth_454_num
+        , retail_year * 100 + retail_month_544 as trade_yearmonth_544_num
+
+        -- Composite year+quarter keys (YYYYQ format, pattern-specific)
+        , retail_year * 10 + ceil(retail_month_445 / 3.0)::int as trade_yearquarter_445_num
+        , retail_year * 10 + ceil(retail_month_454 / 3.0)::int as trade_yearquarter_454_num
+        , retail_year * 10 + ceil(retail_month_544 / 3.0)::int as trade_yearquarter_544_num
+
+        -- Trade month+year display names (e.g., 'March 2026')
+        , case retail_month_445
+            when 1 then 'January' when 2 then 'February' when 3 then 'March'
+            when 4 then 'April' when 5 then 'May' when 6 then 'June'
+            when 7 then 'July' when 8 then 'August' when 9 then 'September'
+            when 10 then 'October' when 11 then 'November' when 12 then 'December'
+        end || ' ' || retail_year::varchar as trade_month_year_445_nm
+        , case retail_month_454
+            when 1 then 'January' when 2 then 'February' when 3 then 'March'
+            when 4 then 'April' when 5 then 'May' when 6 then 'June'
+            when 7 then 'July' when 8 then 'August' when 9 then 'September'
+            when 10 then 'October' when 11 then 'November' when 12 then 'December'
+        end || ' ' || retail_year::varchar as trade_month_year_454_nm
+        , case retail_month_544
+            when 1 then 'January' when 2 then 'February' when 3 then 'March'
+            when 4 then 'April' when 5 then 'May' when 6 then 'June'
+            when 7 then 'July' when 8 then 'August' when 9 then 'September'
+            when 10 then 'October' when 11 then 'November' when 12 then 'December'
+        end || ' ' || retail_year::varchar as trade_month_year_544_nm
+
+        -- Trade month+year abbreviated display (e.g., 'Mar 2026')
+        , case retail_month_445
+            when 1 then 'Jan' when 2 then 'Feb' when 3 then 'Mar'
+            when 4 then 'Apr' when 5 then 'May' when 6 then 'Jun'
+            when 7 then 'Jul' when 8 then 'Aug' when 9 then 'Sep'
+            when 10 then 'Oct' when 11 then 'Nov' when 12 then 'Dec'
+        end || ' ' || retail_year::varchar as trade_month_year_445_abbr
+        , case retail_month_454
+            when 1 then 'Jan' when 2 then 'Feb' when 3 then 'Mar'
+            when 4 then 'Apr' when 5 then 'May' when 6 then 'Jun'
+            when 7 then 'Jul' when 8 then 'Aug' when 9 then 'Sep'
+            when 10 then 'Oct' when 11 then 'Nov' when 12 then 'Dec'
+        end || ' ' || retail_year::varchar as trade_month_year_454_abbr
+        , case retail_month_544
+            when 1 then 'Jan' when 2 then 'Feb' when 3 then 'Mar'
+            when 4 then 'Apr' when 5 then 'May' when 6 then 'Jun'
+            when 7 then 'Jul' when 8 then 'Aug' when 9 then 'Sep'
+            when 10 then 'Oct' when 11 then 'Nov' when 12 then 'Dec'
+        end || ' ' || retail_year::varchar as trade_month_year_544_abbr
+
+        -- Trade year-month sortable text (e.g., '2026-03')
+        , retail_year::varchar || '-' || lpad(retail_month_445::varchar, 2, '0') as trade_year_month_445_txt
+        , retail_year::varchar || '-' || lpad(retail_month_454::varchar, 2, '0') as trade_year_month_454_txt
+        , retail_year::varchar || '-' || lpad(retail_month_544::varchar, 2, '0') as trade_year_month_544_txt
+
+        -- Trade quarter+year display (e.g., 'Q1 2026')
+        , 'Q' || ceil(retail_month_445 / 3.0)::int::varchar || ' ' || retail_year::varchar as trade_quarter_year_445_txt
+        , 'Q' || ceil(retail_month_454 / 3.0)::int::varchar || ' ' || retail_year::varchar as trade_quarter_year_454_txt
+        , 'Q' || ceil(retail_month_544 / 3.0)::int::varchar || ' ' || retail_year::varchar as trade_quarter_year_544_txt
+
         -- Common attributes (using CDC abbreviations)
         , is_leap_week as is_leap_week_flg
         , weeks_in_year as weeks_in_trade_year_num

--- a/models/dw_util/dim_trade_date.sql
+++ b/models/dw_util/dim_trade_date.sql
@@ -405,6 +405,13 @@ with date_sequence as (
         , 'Q' || ceil(retail_month_454 / 3.0)::int::varchar || ' ' || retail_year::varchar as trade_quarter_year_454_txt
         , 'Q' || ceil(retail_month_544 / 3.0)::int::varchar || ' ' || retail_year::varchar as trade_quarter_year_544_txt
 
+        -- Dense sequential counters (for offset arithmetic across year boundaries)
+        , dense_rank() over (order by calendar_date) as trade_day_overall_num
+        , dense_rank() over (order by retail_week_start) as trade_week_overall_num
+        , dense_rank() over (order by retail_year, retail_month_445) as trade_month_445_overall_num
+        , dense_rank() over (order by retail_year, retail_month_454) as trade_month_454_overall_num
+        , dense_rank() over (order by retail_year, retail_month_544) as trade_month_544_overall_num
+
         -- Common attributes (using CDC abbreviations)
         , is_leap_week as is_leap_week_flg
         , weeks_in_year as weeks_in_trade_year_num

--- a/models/dw_util/dim_trade_date.yml
+++ b/models/dw_util/dim_trade_date.yml
@@ -447,6 +447,32 @@ models:
         tests:
           - not_null
 
+      # Dense sequential counters (for offset arithmetic across year boundaries)
+      - name: trade_day_overall_num
+        description: Dense sequential day number across the entire trade calendar. Enables BI offset arithmetic (e.g., today - N days) without year-boundary gaps.
+        tests:
+          - not_null
+
+      - name: trade_week_overall_num
+        description: Dense sequential week number across the entire trade calendar. All days in the same trade week share the same value. Enables week offset arithmetic across year boundaries.
+        tests:
+          - not_null
+
+      - name: trade_month_445_overall_num
+        description: Dense sequential month number for 4-4-5 pattern. All days in the same trade month share the same value. Enables month offset arithmetic across year boundaries.
+        tests:
+          - not_null
+
+      - name: trade_month_454_overall_num
+        description: Dense sequential month number for 4-5-4 pattern. All days in the same trade month share the same value. Enables month offset arithmetic across year boundaries.
+        tests:
+          - not_null
+
+      - name: trade_month_544_overall_num
+        description: Dense sequential month number for 5-4-4 pattern. All days in the same trade month share the same value. Enables month offset arithmetic across year boundaries.
+        tests:
+          - not_null
+
       # Pattern-specific quarter columns
       - name: trade_quarter_445_num
         description: Trade quarter for 4-4-5 pattern

--- a/models/dw_util/dim_trade_date.yml
+++ b/models/dw_util/dim_trade_date.yml
@@ -331,7 +331,122 @@ models:
         description: Trade month name for 5-4-4 pattern
         tests:
           - not_null
-      
+
+      # Pattern-specific month abbreviation columns
+      - name: trade_month_445_abbr
+        description: Three-letter trade month abbreviation for 4-4-5 pattern (Jan, Feb, etc.)
+        tests:
+          - not_null
+
+      - name: trade_month_454_abbr
+        description: Three-letter trade month abbreviation for 4-5-4 pattern (Jan, Feb, etc.)
+        tests:
+          - not_null
+
+      - name: trade_month_544_abbr
+        description: Three-letter trade month abbreviation for 5-4-4 pattern (Jan, Feb, etc.)
+        tests:
+          - not_null
+
+      # Composite year+period keys for grouping and filtering
+      - name: trade_year_week_num
+        description: Trade year and week as YYYYWW integer (e.g., 202613). Same for all patterns. Use for GROUP BY or filtering by trade week across years.
+        tests:
+          - not_null
+
+      - name: trade_yearmonth_445_num
+        description: Trade year and month as YYYYMM integer for 4-4-5 pattern (e.g., 202603). Use for GROUP BY or filtering by trade month across years.
+        tests:
+          - not_null
+
+      - name: trade_yearmonth_454_num
+        description: Trade year and month as YYYYMM integer for 4-5-4 pattern (e.g., 202603). Use for GROUP BY or filtering by trade month across years.
+        tests:
+          - not_null
+
+      - name: trade_yearmonth_544_num
+        description: Trade year and month as YYYYMM integer for 5-4-4 pattern (e.g., 202603). Use for GROUP BY or filtering by trade month across years.
+        tests:
+          - not_null
+
+      - name: trade_yearquarter_445_num
+        description: Trade year and quarter as YYYYQ integer for 4-4-5 pattern (e.g., 20261). Use for GROUP BY or filtering by trade quarter across years.
+        tests:
+          - not_null
+
+      - name: trade_yearquarter_454_num
+        description: Trade year and quarter as YYYYQ integer for 4-5-4 pattern (e.g., 20261). Use for GROUP BY or filtering by trade quarter across years.
+        tests:
+          - not_null
+
+      - name: trade_yearquarter_544_num
+        description: Trade year and quarter as YYYYQ integer for 5-4-4 pattern (e.g., 20261). Use for GROUP BY or filtering by trade quarter across years.
+        tests:
+          - not_null
+
+      # Month+year display names (for BI labels)
+      - name: trade_month_year_445_nm
+        description: "Trade month and year display name for 4-4-5 pattern (e.g., 'March 2026')"
+        tests:
+          - not_null
+
+      - name: trade_month_year_454_nm
+        description: "Trade month and year display name for 4-5-4 pattern (e.g., 'March 2026')"
+        tests:
+          - not_null
+
+      - name: trade_month_year_544_nm
+        description: "Trade month and year display name for 5-4-4 pattern (e.g., 'March 2026')"
+        tests:
+          - not_null
+
+      - name: trade_month_year_445_abbr
+        description: "Trade month and year abbreviated display for 4-4-5 pattern (e.g., 'Mar 2026')"
+        tests:
+          - not_null
+
+      - name: trade_month_year_454_abbr
+        description: "Trade month and year abbreviated display for 4-5-4 pattern (e.g., 'Mar 2026')"
+        tests:
+          - not_null
+
+      - name: trade_month_year_544_abbr
+        description: "Trade month and year abbreviated display for 5-4-4 pattern (e.g., 'Mar 2026')"
+        tests:
+          - not_null
+
+      # Year-month sortable text
+      - name: trade_year_month_445_txt
+        description: "Trade year and month as sortable text for 4-4-5 pattern (e.g., '2026-03')"
+        tests:
+          - not_null
+
+      - name: trade_year_month_454_txt
+        description: "Trade year and month as sortable text for 4-5-4 pattern (e.g., '2026-03')"
+        tests:
+          - not_null
+
+      - name: trade_year_month_544_txt
+        description: "Trade year and month as sortable text for 5-4-4 pattern (e.g., '2026-03')"
+        tests:
+          - not_null
+
+      # Quarter+year display text
+      - name: trade_quarter_year_445_txt
+        description: "Trade quarter and year display for 4-4-5 pattern (e.g., 'Q1 2026')"
+        tests:
+          - not_null
+
+      - name: trade_quarter_year_454_txt
+        description: "Trade quarter and year display for 4-5-4 pattern (e.g., 'Q1 2026')"
+        tests:
+          - not_null
+
+      - name: trade_quarter_year_544_txt
+        description: "Trade quarter and year display for 5-4-4 pattern (e.g., 'Q1 2026')"
+        tests:
+          - not_null
+
       # Pattern-specific quarter columns
       - name: trade_quarter_445_num
         description: Trade quarter for 4-4-5 pattern


### PR DESCRIPTION
## Summary
- Adds 22 new composite columns to `dim_trade_date` that combine trade year with period numbers for unambiguous BI grouping/filtering
- Previously `trade_month_445_num=3` was ambiguous across years — now `trade_yearmonth_445_num=202603` provides a single sortable/groupable value
- Mirrors the pattern already used on the standard calendar side (`yearmonth_num`) and in `dim_fuelz_date` (`fuelz_fm_week_cd`)

### New columns by category

| Category | Columns | Example |
|----------|---------|---------|
| Year+Week key | `trade_year_week_num` | `202613` |
| Year+Month keys | `trade_yearmonth_{445,454,544}_num` | `202603` |
| Year+Quarter keys | `trade_yearquarter_{445,454,544}_num` | `20261` |
| Month+Year names | `trade_month_year_{445,454,544}_nm` | `March 2026` |
| Month+Year abbrs | `trade_month_year_{445,454,544}_abbr` | `Mar 2026` |
| Year-Month text | `trade_year_month_{445,454,544}_txt` | `2026-03` |
| Quarter+Year text | `trade_quarter_year_{445,454,544}_txt` | `Q1 2026` |
| Month abbreviations | `trade_month_{445,454,544}_abbr` | `Mar` |

### Version
Bumps to **2.1.0** (additive, non-breaking).

## Test plan
- [ ] `dbt build -s dim_trade_date` compiles and passes all existing tests
- [ ] Verify composite values are correct: `SELECT trade_year_num, trade_month_445_num, trade_yearmonth_445_num FROM dim_trade_date WHERE trade_year_num = 2026 LIMIT 5`
- [ ] Downstream models (dim_trade_week, dim_trade_month, dim_trade_quarter) unaffected
- [ ] Consuming project (tmc-engineering) can reference new columns after `dbt deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)