### PR TITLE
Release 2.2.1 — accepted_values test argument fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-05-18
+### Fixed
+- Corrected `accepted_values` test arguments in `dim_trade_date.yml` that raised an
+  error under dbt 1.10 (DBT-110)
+
 ## [2.2.0] - 2026-04-01
 ### Fixed
 - `day_nm` now contains full day names (Monday, Tuesday...) instead of abbreviations
@@ -115,4 +120,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - dim_time: Time dimension for intraday analysis
 - Copyright notices to all CDC created resources
 
+[2.2.1]: https://github.com/CloudDataConsulting/cdc_dbt_utils/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/CloudDataConsulting/cdc_dbt_utils/compare/2.1.0...2.2.0

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,7 +8,7 @@
 config-version: 2
 
 name: 'cdc_dbt_utils'
-version: '2.2.0'
+version: '2.2.1'
 profile: 'cdc_dbt_utils'
 
 

--- a/models/dw_util/dim_trade_date.yml
+++ b/models/dw_util/dim_trade_date.yml
@@ -181,7 +181,8 @@ models:
         data_tests:
           - not_null
           - accepted_values:
-              values: ['Q1', 'Q2', 'Q3', 'Q4']
+              arguments:
+                values: ['Q1', 'Q2', 'Q3', 'Q4']
 
       - name: quarter_nm
         description: Quarter name (First, Second, Third, Fourth)
@@ -345,21 +346,24 @@ models:
         data_tests:
           - not_null
           - accepted_values:
-              values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+              arguments:
+                values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
       
       - name: trade_month_454_num
         description: Trade month for 4-5-4 pattern
         data_tests:
           - not_null
           - accepted_values:
-              values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+              arguments:
+                values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
       
       - name: trade_month_544_num
         description: Trade month for 5-4-4 pattern
         data_tests:
           - not_null
           - accepted_values:
-              values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+              arguments:
+                values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
       
       # Pattern-specific month name columns
       - name: trade_month_445_nm
@@ -524,21 +528,24 @@ models:
         data_tests:
           - not_null
           - accepted_values:
-              values: [1, 2, 3, 4]
+              arguments:
+                values: [1, 2, 3, 4]
       
       - name: trade_quarter_454_num
         description: Trade quarter for 4-5-4 pattern
         data_tests:
           - not_null
           - accepted_values:
-              values: [1, 2, 3, 4]
+              arguments:
+                values: [1, 2, 3, 4]
       
       - name: trade_quarter_544_num
         description: Trade quarter for 5-4-4 pattern
         data_tests:
           - not_null
           - accepted_values:
-              values: [1, 2, 3, 4]
+              arguments:
+                values: [1, 2, 3, 4]
       
       # Pattern-specific quarter name columns
       - name: trade_quarter_445_nm


### PR DESCRIPTION
## Summary

Cuts the **2.2.1** maintenance release. This PR delivers both:

- `dd98364` — **Fix accepted_values test arguments** in `dim_trade_date.yml`, which raised an error under dbt 1.10 (DBT-110).
- `1b9a96c` — release bump: `version: '2.2.0'` → `'2.2.1'` in `dbt_project.yml` and a `2.2.1` entry in `CHANGELOG.md`.

## Why

Closes #15.

The accepted_values fix currently lives only on this unmerged branch. Downstream dbt projects (TMC `tmc-engineering`, Aubuchon `MDM-dbt`) are pinning this package by a **raw commit hash** in `packages.yml` as a stopgap, which is fragile. Merging this PR and tagging `2.2.1` lets them pin a proper version tag instead.

## After merge (owner action)

Tag `2.2.1` on the merge commit and publish the release — intentionally not done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)